### PR TITLE
Fix workflow syntax error

### DIFF
--- a/.github/workflows/bump-stytch-deps.yml
+++ b/.github/workflows/bump-stytch-deps.yml
@@ -86,7 +86,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           committer: 'ci-stytch <ci-stytch@stytch.com>'
           commit-message: 'chore: bump @stytch packages to latest'
-          title: ${{ inputs.title || 'chore: bump @stytch packages to latest' }}
+          title: "${{ inputs.title || 'chore: bump @stytch packages to latest' }}"
           body: |
             Bumps all `@stytch/*` and `stytch` packages to their latest versions and updates the lockfile.
 


### PR DESCRIPTION
Fix fun interaction between yaml and GH workflow template syntax 

> When inputs.title is empty, GitHub Actions resolves this to:
> chore: bump `@stytch` packages to latest
> The bare : in that string causes a YAML parse error. The fix is to wrap the entire expression in double quotes